### PR TITLE
fix: pass alpha opam repository to setup-ocaml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,16 +22,16 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: "composite"
+  env:
+    IS_OCAML_5: ${{ startsWith(inputs.ocaml-compiler, 'ocaml-variants.5') || startsWith(inputs.ocaml-compiler, 'ocaml-base-compiler.5') || startsWith(inputs.ocaml-compiler, '5') }}
   steps:
-    - name: "Set up OCaml"
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ inputs.ocaml-compiler }}
         cache-prefix: ${{ inputs.cache-prefix }}
-    - name: "Fix OPAM repo for OCaml 5"
-      if: ${{ startsWith(inputs.ocaml-compiler, 'ocaml-variants.5') || startsWith(inputs.ocaml-compiler, 'ocaml-base-compiler.5') || startsWith(inputs.ocaml-compiler, '5') }}
-      shell: sh
-      run: opam repo add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git --verbose
+        opam-repositories: |
+          default: https://opam.ocaml.org
+          ${{ env.IS_OCAML_5 && 'alpha: git+https://github.com/kit-ty-kate/opam-alpha-repository.git' || '' }}
     - name: "Install the dependencies"
       shell: sh
       run: opam install --with-test ${{inputs.with-doc == 'true' && '--with-doc' || ''}} --deps-only --yes --verbose .


### PR DESCRIPTION
## Patch Description

We've encountered a couple of issues when trying to use packages from the `alpha` repository, as `setup-ocaml` was trying to build them _before_ we added the `alpha` repo, which then caused version conflicts + compilation failures. This patch resolves this by using the `opam-repositories` argument for `setup-ocaml`, which should add the repos at the appropriate time.