### PR TITLE
Fix the repo fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,16 +25,16 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: "composite"
+  env:
+    IS_OCAML_5: ${{ startsWith(inputs.ocaml-compiler, 'ocaml-variants.5') || startsWith(inputs.ocaml-compiler, 'ocaml-base-compiler.5') || startsWith(inputs.ocaml-compiler, '5') }}
   steps:
-    - name: "Set up OCaml"
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ inputs.ocaml-compiler }}
         cache-prefix: ${{ inputs.cache-prefix }}
-    - name: "Fix OPAM repo for OCaml 5"
-      if: ${{ startsWith(inputs.ocaml-compiler, 'ocaml-variants.5') || startsWith(inputs.ocaml-compiler, 'ocaml-base-compiler.5') || startsWith(inputs.ocaml-compiler, '5') }}
-      shell: sh
-      run: opam repo add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git --verbose
+        opam-repositories: |
+          default: https://opam.ocaml.org
+          ${{ env.IS_OCAML_5 && 'alpha: git+https://github.com/kit-ty-kate/opam-alpha-repository.git' || '' }}
     - name: "Install the dependencies"
       shell: sh
       run: opam install --with-test ${{inputs.with-doc == 'true' && '--with-doc' || ''}} --deps-only --yes --verbose .

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
   env:
     IS_OCAML_5: ${{ startsWith(inputs.ocaml-compiler, 'ocaml-variants.5') || startsWith(inputs.ocaml-compiler, 'ocaml-base-compiler.5') || startsWith(inputs.ocaml-compiler, '5') }}
   steps:
+    - name: "Set up OCaml"
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ inputs.ocaml-compiler }}

--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,11 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: "composite"
-  env:
-    IS_OCAML_5: ${{ startsWith(inputs.ocaml-compiler, 'ocaml-variants.5') || startsWith(inputs.ocaml-compiler, 'ocaml-base-compiler.5') || startsWith(inputs.ocaml-compiler, '5') }}
   steps:
+    - name: "Detect OCaml 5"
+      shell: sh
+      run: |
+        echo "IS_OCAML_5=${{ startsWith(inputs.ocaml-compiler, 'ocaml-variants.5') || startsWith(inputs.ocaml-compiler, 'ocaml-base-compiler.5') || startsWith(inputs.ocaml-compiler, '5') }}" >> $GITHUB_ENV
     - name: "Set up OCaml"
       uses: ocaml/setup-ocaml@v2
       with:


### PR DESCRIPTION
## Patch Description

Oops! Made a couple of mistakes on #1. This PR adds the `name` field to the `setup-ocaml` step, and sets the `IS_OCAML_5` variable via `GITHUB_ENV`.